### PR TITLE
Add license headers to Python files

### DIFF
--- a/IO_operations/read_data.py
+++ b/IO_operations/read_data.py
@@ -1,3 +1,28 @@
+"""
+@file read_data.py
+
+@brief Dispatch reading of input files depending on program mode.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   READ_DATA.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/read_filerun.py
+++ b/IO_operations/read_filerun.py
@@ -1,3 +1,28 @@
+"""
+@file read_filerun.py
+
+@brief Parse .in and .pfs files for file-run mode.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   READ_FILERUN.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/read_srun.py
+++ b/IO_operations/read_srun.py
@@ -1,3 +1,28 @@
+"""
+@file read_srun.py
+
+@brief Parse .srun single-run files into dataframe.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   READ_SRUN.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/read_xlsx.py
+++ b/IO_operations/read_xlsx.py
@@ -1,3 +1,28 @@
+"""
+@file read_xlsx.py
+
+@brief Read .xlsx input file into dataframe.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   READ_XLSX.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/retrieve_data.py
+++ b/IO_operations/retrieve_data.py
@@ -1,3 +1,28 @@
+"""
+@file retrieve_data.py
+
+@brief Wrapper to retrieve data for current case based on mode.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   RETRIEVE_DATA.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/retrieve_data_filerun.py
+++ b/IO_operations/retrieve_data_filerun.py
@@ -1,3 +1,28 @@
+"""
+@file retrieve_data_filerun.py
+
+@brief Extract inputs for file-run cases from dataframe.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   RETRIEVE_DATA_FILERUN.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/retrieve_data_srun.py
+++ b/IO_operations/retrieve_data_srun.py
@@ -1,3 +1,28 @@
+"""
+@file retrieve_data_srun.py
+
+@brief Extract inputs for .srun single-run cases.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   RETRIEVE_DATA_SRUN.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/retrieve_data_xlsx.py
+++ b/IO_operations/retrieve_data_xlsx.py
@@ -1,3 +1,28 @@
+"""
+@file retrieve_data_xlsx.py
+
+@brief Extract inputs from xlsx case data.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   RETRIEVE_DATA_XLSX.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/retrieve_helper.py
+++ b/IO_operations/retrieve_helper.py
@@ -1,3 +1,28 @@
+"""
+@file retrieve_helper.py
+
+@brief Utility functions for retrieving and validating input data.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   RETRIEVE_HELPER.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/write_output.py
+++ b/IO_operations/write_output.py
@@ -1,3 +1,28 @@
+"""
+@file write_output.py
+
+@brief Select appropriate writer based on run mode.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   WRITE_OUTPUT.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/write_output_filerun.py
+++ b/IO_operations/write_output_filerun.py
@@ -1,3 +1,28 @@
+"""
+@file write_output_filerun.py
+
+@brief Write results for file run mode.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   WRITE_OUTPUT_FILERUN.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/write_output_srun.py
+++ b/IO_operations/write_output_srun.py
@@ -1,3 +1,28 @@
+"""
+@file write_output_srun.py
+
+@brief Write results for single run mode.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   WRITE_OUTPUT_SRUN.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/IO_operations/write_output_xlsx.py
+++ b/IO_operations/write_output_xlsx.py
@@ -1,3 +1,28 @@
+"""
+@file write_output_xlsx.py
+
+@brief Generate xlsx output files.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 # .................................................
 #   WRITE_OUTPUT_XLSX.PY, v2.0.0, December 2024, Domenico Lanza.
 # .................................................

--- a/heat_flux/continuity.py
+++ b/heat_flux/continuity.py
@@ -1,3 +1,28 @@
+"""
+@file continuity.py
+
+@brief Integrate continuity equation dV/deta = -F using Simpson's rule.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   CONTINUITY.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/heat_flux/eq_diff_solve.py
+++ b/heat_flux/eq_diff_solve.py
@@ -1,3 +1,28 @@
+"""
+@file eq_diff_solve.py
+
+@brief Tridiagonal solver for boundary layer differential equations.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   EQ_DIFF_SOLVE.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/heat_flux/first_deriv.py
+++ b/heat_flux/first_deriv.py
@@ -1,3 +1,28 @@
+"""
+@file first_deriv.py
+
+@brief Finite difference utilities to compute first derivatives of arrays.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   FIRST_DERIV, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/heat_flux/heat_flux.py
+++ b/heat_flux/heat_flux.py
@@ -1,3 +1,28 @@
+"""
+@file heat_flux.py
+
+@brief Dispatch heat flux calculations for available laws.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   HEAT_FLUX.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/heat_flux/heat_flux_hf_law0.py
+++ b/heat_flux/heat_flux_hf_law0.py
@@ -1,3 +1,28 @@
+"""
+@file heat_flux_hf_law0.py
+
+@brief Solve boundary layer equations for exact heat flux law (hf_law=0).
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   HEAT_FLUX_HF_LAW0.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/heat_flux/heat_flux_hf_law0_properties.py
+++ b/heat_flux/heat_flux_hf_law0_properties.py
@@ -1,3 +1,28 @@
+"""
+@file heat_flux_hf_law0_properties.py
+
+@brief Evaluate edge and wall flow properties for hf_law=0 heat flux model.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   HEAT_FLUX_HF_LAW0_PROPERTIES.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/heat_flux/heat_flux_hf_law1.py
+++ b/heat_flux/heat_flux_hf_law1.py
@@ -1,3 +1,28 @@
+"""
+@file heat_flux_hf_law1.py
+
+@brief Compute stagnation heat flux using the Fay-Riddell law.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   HEAT_FLUX_HF_LAW1.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/main.py
+++ b/main.py
@@ -1,3 +1,28 @@
+"""
+@file main.py
+
+@brief Entry point orchestrating data reading, solution, and output.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #       PlasFlowSolver Program
 #       main.py: main script

--- a/runner.py
+++ b/runner.py
@@ -1,3 +1,28 @@
+"""
+@file runner.py
+
+@brief Convenience script to run main.py on multiple XLSX cases.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 # This is not a project file, but a script that can be used to run the main.py script on multiple xlsx files
 
 import subprocess  # For running python scripts from python

--- a/system_resolution/barker_effect.py
+++ b/system_resolution/barker_effect.py
@@ -1,3 +1,28 @@
+"""
+@file barker_effect.py
+
+@brief Evaluate Pitot pressure corrections using Barker effects.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   BARKER_EFFECT.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/system_resolution/jacobian_matrix.py
+++ b/system_resolution/jacobian_matrix.py
@@ -1,3 +1,28 @@
+"""
+@file jacobian_matrix.py
+
+@brief Build Jacobian matrix for nonlinear flow system.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   JACOBIAN_MATRIX.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/system_resolution/newton_operations.py
+++ b/system_resolution/newton_operations.py
@@ -1,3 +1,28 @@
+"""
+@file newton_operations.py
+
+@brief Helper operations for Newton-Raphson convergence.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   NEWTON_OPERATIONS.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/system_resolution/out_properties.py
+++ b/system_resolution/out_properties.py
@@ -1,3 +1,28 @@
+"""
+@file out_properties.py
+
+@brief Collect and organize final flow properties for output.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   OUT_PROPERTIES.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/system_resolution/system_solve.py
+++ b/system_resolution/system_solve.py
@@ -1,3 +1,28 @@
+"""
+@file system_solve.py
+
+@brief Linear system solver for Newton-Raphson iterations.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   SYSTEM_SOLVE.PY, v1.0.0, April 2024, Domenico Lanza.
 #.................................................

--- a/system_resolution/thermodyn.py
+++ b/system_resolution/thermodyn.py
@@ -1,3 +1,28 @@
+"""
+@file thermodyn.py
+
+@brief Compute enthalpy and entropy from pressure and temperature.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   THERMODYN.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/utils/classes.py
+++ b/utils/classes.py
@@ -1,3 +1,28 @@
+"""
+@file classes.py
+
+@brief Definitions of program constants and data containers.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   CLASSES.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/utils/database_manager.py
+++ b/utils/database_manager.py
@@ -1,3 +1,28 @@
+"""
+@file database_manager.py
+
+@brief Build and update initial condition database.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   DATABASE_MANAGER.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/utils/exit_program.py
+++ b/utils/exit_program.py
@@ -1,3 +1,28 @@
+"""
+@file exit_program.py
+
+@brief Cleanup temporary files and exit gracefully.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   EXIT_PROGRAM.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/utils/initial_conditions_map.py
+++ b/utils/initial_conditions_map.py
@@ -1,3 +1,28 @@
+"""
+@file initial_conditions_map.py
+
+@brief Manage and interpolate initial conditions database.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   INITIAL_CONDITIONS_MAP.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/utils/mpp_memory_fixer.py
+++ b/utils/mpp_memory_fixer.py
@@ -1,3 +1,28 @@
+"""
+@file mpp_memory_fixer.py
+
+@brief Temporary workaround for Mutation++ memory leak.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   MPP_MEMORY_FIXER.PY, v2.0.0, April 2024, Domenico Lanza.
 #.................................................

--- a/utils/presentation.py
+++ b/utils/presentation.py
@@ -1,3 +1,28 @@
+"""
+@file presentation.py
+
+@brief Print program splash screen and credits.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   PRESENTATION.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/utils/prompt_program_mode.py
+++ b/utils/prompt_program_mode.py
@@ -1,3 +1,28 @@
+"""
+@file prompt_program_mode.py
+
+@brief Prompt user to select execution mode.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   PROMPT_PROGRAM_MODE.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................

--- a/utils/script_run.py
+++ b/utils/script_run.py
@@ -1,3 +1,28 @@
+"""
+@file script_run.py
+
+@brief Utilities for detecting and reading script-based runs.
+
+Copyright (C) 2023-2025 The Board of Trustees of the University of Illinois.
+All rights reserved.
+
+This file is part of PlasFlowSolver: a data reduction model for ICP wind tunnels.
+
+PlasFlowSolver is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+PlasFlowSolver is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PlasFlowSolver.  If not, see 
+<http://www.gnu.org/licenses/>.
+"""
+
 #.................................................
 #   SCRIPT_RUN.PY, v2.0.0, December 2024, Domenico Lanza.
 #.................................................


### PR DESCRIPTION
## Summary
- Add standard GPL license headers with file descriptions to all Python modules.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4501dc1848329935fb440c85d4768